### PR TITLE
Add LLaMA example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# ai
+# AI
+
+This repository contains a simple example of how to load and run a LLaMA model using Hugging Face's `transformers` library.
+
+## Requirements
+
+- Python 3.10+
+- PyTorch
+- transformers >= 4.31
+
+## Example
+
+The `llama_sample.py` script demonstrates how to load the base model and run inference with a prompt. You will need access to the LLaMA model weights from Meta. Update the `model_name` in the script to the path where you've stored the model.
+
+```bash
+pip install torch transformers
+python llama_sample.py
+```

--- a/llama_sample.py
+++ b/llama_sample.py
@@ -1,0 +1,29 @@
+"""Simple example of running a LLaMA model with transformers."""
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+
+def main():
+    # Replace with your local path or Hugging Face model hub name
+    model_name = "path/to/llama"
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    model = AutoModelForCausalLM.from_pretrained(model_name, torch_dtype=torch.float16)
+
+    prompt = "Introduce yourself in one sentence."
+    inputs = tokenizer(prompt, return_tensors="pt").to(model.device)
+
+    with torch.no_grad():
+        outputs = model.generate(
+            **inputs,
+            max_new_tokens=50,
+            do_sample=True,
+            top_p=0.9,
+            temperature=0.8,
+        )
+    print(tokenizer.decode(outputs[0], skip_special_tokens=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a README with quick instructions for running LLaMA
- provide a simple `llama_sample.py` demo script

## Testing
- `python llama_sample.py` *(fails: No module named 'transformers')*

## Sourcery 요약

Hugging Face의 transformers 라이브러리를 사용하여 LLaMA 모델을 로드하고 실행하는 예제 스크립트와 관련 문서를 제공합니다.

새로운 기능:
- LLaMA 모델을 로드하고 텍스트를 생성하는 `llama_sample.py` 데모 스크립트를 추가합니다.

문서:
- LLaMA 예제에 대한 설치 요구 사항 및 샘플 사용 지침이 포함된 README를 추가합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide an example script and accompanying documentation for loading and running LLaMA models using Hugging Face’s transformers library

New Features:
- Add `llama_sample.py` demo script to load a LLaMA model and generate text.

Documentation:
- Add README with installation requirements and sample usage instructions for the LLaMA example.

</details>